### PR TITLE
Use the docker image we build (instead of the upstream one)

### DIFF
--- a/ci/auto-merge.yml
+++ b/ci/auto-merge.yml
@@ -18,7 +18,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfje/java-buildpack
+    repository: splatform/java-buildpack
 
 inputs:
 - name: downstream

--- a/ci/package-test.yml
+++ b/ci/package-test.yml
@@ -18,7 +18,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfje/java-buildpack
+    repository: splatform/java-buildpack
 
 inputs:
 - name: java-buildpack

--- a/ci/unit-test.yml
+++ b/ci/unit-test.yml
@@ -18,7 +18,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfje/java-buildpack
+    repository: splatform/java-buildpack
 
 inputs:
 - name: java-buildpack

--- a/ci/versions-json.yml
+++ b/ci/versions-json.yml
@@ -18,7 +18,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfje/java-buildpack
+    repository: splatform/java-buildpack
 
 inputs:
 - name: java-buildpack

--- a/ci/versions-yaml.yml
+++ b/ci/versions-yaml.yml
@@ -18,7 +18,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfje/java-buildpack
+    repository: splatform/java-buildpack
 
 inputs:
 - name: java-buildpack

--- a/ci/versions.yml
+++ b/ci/versions.yml
@@ -18,7 +18,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: cfje/java-buildpack
+    repository: splatform/java-buildpack
 
 inputs:
 - name: java-buildpack

--- a/config/repository.yml
+++ b/config/repository.yml
@@ -15,4 +15,4 @@
 
 # Repository configuration
 ---
-default_repository_root: https://minio.from-the.cloud:9000/java-buildpack
+default_repository_root: https://suse-cf-java-buildpack.s3.amazonaws.com/


### PR DESCRIPTION
The upstream docker image doesn't have the rbenv versions we need. Still more problems to fix but this is a first step.